### PR TITLE
Non-generic ReactiveUI.ReactiveCommand has removed

### DIFF
--- a/ReactiveUI.Winforms.Samples.Bindings/ReactiveUI.Winforms.Samples.Bindings.csproj
+++ b/ReactiveUI.Winforms.Samples.Bindings/ReactiveUI.Winforms.Samples.Bindings.csproj
@@ -35,21 +35,27 @@
     <StartupObject>ReactiveUI.Winforms.Samples.Bindings.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DynamicData, Version=7.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicData.7.1.1\lib\net461\DynamicData.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ReactiveUI, Version=8.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReactiveUI.8.0.1\lib\net461\ReactiveUI.dll</HintPath>
+    <Reference Include="ReactiveUI, Version=13.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReactiveUI.13.1.1\lib\net461\ReactiveUI.dll</HintPath>
     </Reference>
-    <Reference Include="ReactiveUI.Winforms, Version=8.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReactiveUI.WinForms.8.0.1\lib\net461\ReactiveUI.Winforms.dll</HintPath>
+    <Reference Include="ReactiveUI.Winforms, Version=13.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReactiveUI.WinForms.13.1.1\lib\net461\ReactiveUI.Winforms.dll</HintPath>
     </Reference>
-    <Reference Include="Splat, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Splat.4.0.0\lib\net461\Splat.dll</HintPath>
+    <Reference Include="Splat, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Splat.10.0.1\lib\net461\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Primitives.4.3.0\lib\net45\System.Drawing.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive, Version=5.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.5.0.0\lib\netstandard2.0\System.Reactive.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
@@ -65,6 +71,15 @@
     </Reference>
     <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Xaml" />

--- a/ReactiveUI.Winforms.Samples.Bindings/packages.config
+++ b/ReactiveUI.Winforms.Samples.Bindings/packages.config
@@ -1,13 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ReactiveUI" version="8.0.1" targetFramework="net461" />
-  <package id="ReactiveUI.WinForms" version="8.0.1" targetFramework="net461" />
-  <package id="Splat" version="4.0.0" targetFramework="net461" />
+  <package id="DynamicData" version="7.1.1" targetFramework="net461" />
+  <package id="ReactiveUI" version="13.1.1" targetFramework="net461" />
+  <package id="ReactiveUI.WinForms" version="13.1.1" targetFramework="net461" />
+  <package id="Splat" version="10.0.1" targetFramework="net461" />
   <package id="System.Drawing.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Reactive" version="3.1.1" targetFramework="net461" />
+  <package id="System.Reactive" version="5.0.0" targetFramework="net461" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.WindowsRuntime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/ReactiveUI.Winforms.Samples.Commands/App.config
+++ b/ReactiveUI.Winforms.Samples.Commands/App.config
@@ -7,7 +7,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6000.0" newVersion="3.0.6000.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6000.0" newVersion="3.0.6000.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6000.0" newVersion="3.0.6000.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ReactiveUI.Winforms.Samples.Commands/ReactiveUI.Winforms.Samples.Commands.csproj
+++ b/ReactiveUI.Winforms.Samples.Commands/ReactiveUI.Winforms.Samples.Commands.csproj
@@ -35,35 +35,50 @@
     <StartupObject>ReactiveUI.Winforms.Samples.Commands.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DynamicData, Version=7.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicData.7.1.1\lib\net461\DynamicData.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ReactiveUI, Version=8.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReactiveUI.8.0.1\lib\net461\ReactiveUI.dll</HintPath>
+    <Reference Include="ReactiveUI, Version=13.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReactiveUI.13.1.1\lib\net461\ReactiveUI.dll</HintPath>
     </Reference>
-    <Reference Include="ReactiveUI.Winforms, Version=8.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReactiveUI.WinForms.8.0.1\lib\net461\ReactiveUI.Winforms.dll</HintPath>
+    <Reference Include="ReactiveUI.Winforms, Version=13.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReactiveUI.WinForms.13.1.1\lib\net461\ReactiveUI.Winforms.dll</HintPath>
     </Reference>
-    <Reference Include="Splat, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Splat.4.0.0\lib\net461\Splat.dll</HintPath>
+    <Reference Include="Splat, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Splat.10.0.1\lib\net461\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Primitives.4.3.0\lib\net45\System.Drawing.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive, Version=5.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.5.0.0\lib\netstandard2.0\System.Reactive.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.5.0.0\lib\netstandard2.0\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.5.0.0\lib\netstandard2.0\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.5.0.0\lib\netstandard2.0\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.5.0.0\lib\netstandard2.0\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Xaml" />

--- a/ReactiveUI.Winforms.Samples.Commands/ViewModels/MainViewModel.cs
+++ b/ReactiveUI.Winforms.Samples.Commands/ViewModels/MainViewModel.cs
@@ -33,9 +33,9 @@ namespace ReactiveUI.Winforms.Samples.Commands.ViewModels
             set => this.RaiseAndSetIfChanged(ref _withCanExecuteParameter, value);
         }
 
-        public ReactiveCommand ParameterlessCommand { get; }
-        public ReactiveCommand WithParameterCommand { get; }
-        public ReactiveCommand WithCanExecuteCommand { get; }
+        public ReactiveCommand<Unit, Unit> ParameterlessCommand { get; }
+        public ReactiveCommand<string, Unit> WithParameterCommand { get; }
+        public ReactiveCommand<Unit, Unit> WithCanExecuteCommand { get; }
 
         private void Parameterless()
         {

--- a/ReactiveUI.Winforms.Samples.Commands/ViewModels/MainViewModel.cs
+++ b/ReactiveUI.Winforms.Samples.Commands/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Reactive;
+using System.Reactive.Linq;
 using System.Windows;
 
 namespace ReactiveUI.Winforms.Samples.Commands.ViewModels

--- a/ReactiveUI.Winforms.Samples.Commands/packages.config
+++ b/ReactiveUI.Winforms.Samples.Commands/packages.config
@@ -1,13 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ReactiveUI" version="8.0.1" targetFramework="net461" />
-  <package id="ReactiveUI.WinForms" version="8.0.1" targetFramework="net461" />
-  <package id="Splat" version="4.0.0" targetFramework="net461" />
+  <package id="DynamicData" version="7.1.1" targetFramework="net461" />
+  <package id="ReactiveUI" version="13.1.1" targetFramework="net461" />
+  <package id="ReactiveUI.WinForms" version="13.1.1" targetFramework="net461" />
+  <package id="Splat" version="10.0.1" targetFramework="net461" />
   <package id="System.Drawing.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Reactive" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net461" />
+  <package id="System.Reactive" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Core" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Interfaces" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Linq" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.PlatformServices" version="5.0.0" targetFramework="net461" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.WindowsRuntime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/ReactiveUI.Winforms.Samples.Routing/App.config
+++ b/ReactiveUI.Winforms.Samples.Routing/App.config
@@ -7,7 +7,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6000.0" newVersion="3.0.6000.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6000.0" newVersion="3.0.6000.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ReactiveUI.Winforms.Samples.Routing/ReactiveUI.Winforms.Samples.Routing.csproj
+++ b/ReactiveUI.Winforms.Samples.Routing/ReactiveUI.Winforms.Samples.Routing.csproj
@@ -35,16 +35,19 @@
     <StartupObject>ReactiveUI.Winforms.Samples.Routing.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DynamicData, Version=7.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicData.7.1.1\lib\net461\DynamicData.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="ReactiveUI, Version=8.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReactiveUI.8.0.1\lib\net461\ReactiveUI.dll</HintPath>
+    <Reference Include="ReactiveUI, Version=13.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReactiveUI.13.1.1\lib\net461\ReactiveUI.dll</HintPath>
     </Reference>
-    <Reference Include="ReactiveUI.Winforms, Version=8.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReactiveUI.WinForms.8.0.1\lib\net461\ReactiveUI.Winforms.dll</HintPath>
+    <Reference Include="ReactiveUI.Winforms, Version=13.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReactiveUI.WinForms.13.1.1\lib\net461\ReactiveUI.Winforms.dll</HintPath>
     </Reference>
-    <Reference Include="Splat, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Splat.4.0.0\lib\net461\Splat.dll</HintPath>
+    <Reference Include="Splat, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Splat.10.0.1\lib\net461\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -52,20 +55,32 @@
     <Reference Include="System.Drawing.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Primitives.4.3.0\lib\net45\System.Drawing.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive, Version=5.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.5.0.0\lib\netstandard2.0\System.Reactive.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.5.0.0\lib\netstandard2.0\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.5.0.0\lib\netstandard2.0\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.5.0.0\lib\netstandard2.0\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.6000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.5.0.0\lib\netstandard2.0\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />

--- a/ReactiveUI.Winforms.Samples.Routing/ViewModels/ShellViewModel.cs
+++ b/ReactiveUI.Winforms.Samples.Routing/ViewModels/ShellViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive;
 
 namespace ReactiveUI.Winforms.Samples.Routing.ViewModels
 {
@@ -32,10 +33,10 @@ namespace ReactiveUI.Winforms.Samples.Routing.ViewModels
             set => this.RaiseAndSetIfChanged(ref _applicationTitle, value);
         }
 
-        public ReactiveCommand ShowHomeCommand { get; }
-        public ReactiveCommand ShowAboutCommand { get; }
-        public ReactiveCommand ShowContactCommand { get; }
-        public ReactiveCommand GoBackCommand { get; }
+        public ReactiveCommand<Unit,Unit> ShowHomeCommand { get; }
+        public ReactiveCommand<Unit,Unit> ShowAboutCommand { get; }
+        public ReactiveCommand<Unit, Unit> ShowContactCommand { get; }
+        public ReactiveCommand<Unit, Unit> GoBackCommand { get; }
 
         private void ShowHome()
         {

--- a/ReactiveUI.Winforms.Samples.Routing/packages.config
+++ b/ReactiveUI.Winforms.Samples.Routing/packages.config
@@ -1,13 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ReactiveUI" version="8.0.1" targetFramework="net461" />
-  <package id="ReactiveUI.WinForms" version="8.0.1" targetFramework="net461" />
-  <package id="Splat" version="4.0.0" targetFramework="net461" />
+  <package id="DynamicData" version="7.1.1" targetFramework="net461" />
+  <package id="ReactiveUI" version="13.1.1" targetFramework="net461" />
+  <package id="ReactiveUI.WinForms" version="13.1.1" targetFramework="net461" />
+  <package id="Splat" version="10.0.1" targetFramework="net461" />
   <package id="System.Drawing.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Reactive" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net461" />
-  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net461" />
+  <package id="System.Reactive" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Core" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Interfaces" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Linq" version="5.0.0" targetFramework="net461" />
+  <package id="System.Reactive.PlatformServices" version="5.0.0" targetFramework="net461" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.WindowsRuntime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Non-generic ReactiveUI.ReactiveCommand has removed in the newest versions. Generic ReactiveUI.ReactiveCommand<Unit, Unit> is used instead for parameterless and void type commands
https://stackoverflow.com/questions/65807429/how-to-implement-command-pattern-in-the-newest-versions-of-reactiveui